### PR TITLE
Release 0.2.0 - Map domain to API

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   terraform:
     name: 'Terraform'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:

--- a/example/main.tf
+++ b/example/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "certificate" {
-  source = "github.com/silinternational/terraform-aws-acm-certificate?ref=0.1.0"
+  source = "github.com/silinternational/terraform-aws-acm-certificate?ref=0.2.0"
 
   certificate_domain_name = local.full_domain_name
   cloudflare_zone_name    = var.cloudflare_zone_name
@@ -12,9 +12,10 @@ module "certificate" {
 }
 
 module "domain" {
-  source = "github.com/silinternational/terraform-aws-api-gateway-custom-domain?ref=0.1.0"
+  source = "github.com/silinternational/terraform-aws-api-gateway-custom-domain?ref=0.2.0"
 
   api_name        = var.api_name
   certificate_arn = module.certificate.certificate_arn
   domain_name     = local.full_domain_name
+  stage           = var.stage
 }

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -28,3 +28,8 @@ variable "create_dns_validation" {
   type        = bool
   default     = true
 }
+
+variable "stage" {
+  description = "The stage of the API to map this domain name to (e.g. 'dev' or 'prod')"
+  type        = string
+}

--- a/main.tf
+++ b/main.tf
@@ -14,3 +14,9 @@ resource "aws_api_gateway_domain_name" "this" {
     types = ["REGIONAL"]
   }
 }
+
+resource "aws_api_gateway_base_path_mapping" "this" {
+  api_id      = data.aws_api_gateway_rest_api.this.id
+  domain_name = var.domain_name
+  stage_name  = var.stage
+}

--- a/test/main.tf
+++ b/test/main.tf
@@ -5,6 +5,7 @@ module "test" {
   api_name        = "my-api"
   certificate_arn = "fake-aws-arn"
   domain_name     = "example.com"
+  stage           = "dev"
 }
 
 provider "aws" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,8 @@ variable "domain_name" {
   description = "The exact domain name for the API Gateway custom domain"
   type        = string
 }
+
+variable "stage" {
+  description = "The stage of the API to map this domain name to (e.g. 'dev' or 'prod')"
+  type        = string
+}


### PR DESCRIPTION
### Changed (BREAKING)
- Add new required variable for which API stage to use

### Fixed
- Add resource to map domain name to API stage
- Add new `stage` variable to test
- Update example usage
- Specify at least a major version of Ubuntu (used for running test in GitHub Actions)